### PR TITLE
Temporarily fix discord WS connection

### DIFF
--- a/src/dscord/gateway/client.d
+++ b/src/dscord/gateway/client.d
@@ -111,7 +111,12 @@ class GatewayClient {
 
     // Start the main task
     this.log.infof("Starting connection to Gateway WebSocket (%s)", this.cachedGatewayURL);
-    this.sock = connectWebSocket(URL(this.cachedGatewayURL));
+
+    //HACK: vibe-d won't allow connections to wss:// addresses, so we use HTTPS.
+    URL url = URL(this.cachedGatewayURL);
+    url.schema = "https";
+    this.sock = connectWebSocket(url);
+
     runTask(toDelegate(&this.run));
   }
 


### PR DESCRIPTION
This patch temporarily fixes connections, as vibe-d complains about the wss:// url that the gateway returns.